### PR TITLE
Tidy add element

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
 		}
 	},
 	"config": {
+		"discard-changes": true,
+		"optimize-autoloader": true,
 		"preferred-install": "dist"
 	},
 	"minimum-stability": "dev",

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -1,11 +1,5 @@
 <?php namespace Stolz\HtmlTidy;
 
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
-
 class Middleware implements \Illuminate\Contracts\Routing\Middleware
 {
 	/**
@@ -17,36 +11,6 @@ class Middleware implements \Illuminate\Contracts\Routing\Middleware
 	 */
 	public function handle($request, \Closure $next)
 	{
-		$response = $next($request);
-
-		// Check PHP extension
-		if( ! extension_loaded('tidy') or ! config('tidy.enabled'))
-			return $response;
-
-		// Skip special response types
-		if(($response instanceof BinaryFileResponse) or
-		($response instanceof JsonResponse) or
-		($response instanceof RedirectResponse) or
-		($response instanceof StreamedResponse))
-			return $response;
-
-		// Check request
-		if($request->ajax() and ! config('tidy.ajax'))
-			return $response;
-
-		// Convert unknown responses
-		if( ! $response instanceof Response)
-		{
-			$response = new Response($response);
-			if( ! $response->headers->has('content-type'))
-				$response->headers->set('content-type', 'text/html');
-		}
-
-		// If response is HTML parse it
-		$contentType = $response->headers->get('content-type');
-		if(str_contains($contentType, 'text/html'))
-			$response->setContent(app('stolz.tidy')->parse($response->getContent()));
-
-		return $response;
+		return app('stolz.tidy')->handle($request, $next($request));
 	}
 }

--- a/src/Tidy.php
+++ b/src/Tidy.php
@@ -41,13 +41,29 @@ class Tidy
 	 * Errors container opening tag
 	 * @var string
 	 */
-	protected $container_open_tag = '<div id="tidy_errors" style="position: absolute;right: 0;top: 0;z-index: 100;padding:1em;margin:1em;border:1px solid #DC0024;font-family: Sans-Serif;background-color:#FFE5E5;color:#DC0024"><a style="float:right;cursor:pointer;color:blue;margin:-15px" onclick="document.getElementById(\'tidy_errors\').style.display = \'none\'">[x]</a>';
+	protected $container_open_tag = '
+<style type="text/css">
+#tidy-errors {
+    font-family: Sans-Serif;
+    position: absolute; right: 0; top: 0; z-index: 100;
+    padding:1em; margin:1em;
+    border:1px solid #DC0024;
+    color:#DC0024 background-color:#FFE5E5; }
+#hide-tidy-errors {
+    float:right; cursor:pointer; color:blue; margin:-15px }
+</style>
+<div id="tidy-errors"
+    <a id="hide-tidy-errors"
+    onclick="document.getElementById(\'tidy-errors\').style.display = \'none\'">[x]</a>
+';
 
 	/**
 	 * Errors container closing tag
 	 * @var string
 	 */
-	protected $container_close_tag = '</div>';
+	protected $container_close_tag = '
+</div>
+';
 
 	/**
 	 * Options passed to HTML Tidy parseString() function.
@@ -115,6 +131,14 @@ class Tidy
 		}
 	}
 
+	public function addElement($element, $type = 'inline')
+	{
+		if ($type == 'inline' or $type == 'new-inline-tags') {
+			$this->tidy_options['new-inline-tags'] .= ",$element";
+		} elseif ($type == 'block' or $type == 'new-blocklevel-tags') {
+			$this->tidy_options['new-blocklevel-tags'] .= ",$element";
+		}
+	}
 
 	/**
 	 * Handle an incoming request and its response.

--- a/src/config.php
+++ b/src/config.php
@@ -29,10 +29,10 @@ return [
 	'display_errors' => true,
 
 	// Errors container opening tag
-	'container_open_tag' => '<div id="tidy_errors" style="position: absolute;right: 0;top: 0;z-index: 100;padding:1em;margin:1em;border:1px solid #DC0024;font-family: Sans-Serif;background-color:#FFE5E5;color:#DC0024"><a style="float:right;cursor:pointer;color:blue;margin:-15px" onclick="document.getElementById(\'tidy_errors\').style.display = \'none\'">[x]</a>',
+	//'container_open_tag' => '<div id="tidy_errors" style="position: absolute;right: 0;top: 0;z-index: 100;padding:1em;margin:1em;border:1px solid #DC0024;font-family: Sans-Serif;background-color:#FFE5E5;color:#DC0024"><a style="float:right;cursor:pointer;color:blue;margin:-15px" onclick="document.getElementById(\'tidy_errors\').style.display = \'none\'">[x]</a>',
 
 	// Errors container closing tag
-	'container_close_tag' => '</div>',
+	//'container_close_tag' => '</div>',
 
 	// Options passed to HTML Tidy parseString() function. Docs: http://tidy.sourceforge.net/docs/quickref.html
 	'tidy_options' => [


### PR DESCRIPTION
This patch allows us to add any elements to list of exceptions, so that tidy will not report:

```
line 80 column 1 - Error: &lt;time-left&gt; is not recognized!<br />
line 80 column 1 - Warning: discarding unexpected &lt;time-left&gt;<br />
line 81 column 1 - Warning: discarding unexpected &lt;/time-left&gt;<br />
```

.. and allow us to print custom html elements.

The patch is based on the development branch and includes changes from the composer repository (I don't know which is more recent, but I'm guessing this, so you probably want to discard the first commit in this branch).
